### PR TITLE
Support configuring the list of verbs used for slapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@ _Substitute the appropriate `pip` command based on your environment (e.g.
 _If your Sopel configuration requires it, run `sopel-plugins enable slap`,
 passing the appropriate config name to `-c` if you have multiple bots._
 
+## Configuration
+
+The easiest way to configure this plugin is via Sopel's built-in wizard:
+
+```sh
+sopel-plugins configure slap
+```
+
+Right now, there is only one option:
+
+* `verbs`: A list of verbs to choose from when slapping people. Overrides the
+  default list if set.
+
+Probably, the easiest way to make a custom list is to just press Enter twice
+when the config wizard asks for a list of verbs, which will add the default
+list to your bot's `.cfg` file. Then you can use your favorite text editor.
+
+_(We're aware that Sopel's wizard doesn't have great UX when it comes to
+entering lists. It'll get worked on someday, probably.)_
+
 ## Commands
 
 <dl>

--- a/sopel_slap/config.py
+++ b/sopel_slap/config.py
@@ -1,0 +1,37 @@
+"""Configuration definitions
+
+Part of `sopel-slap`.
+
+Copyright 2024, dgw, technobabbl.es
+
+https://sopel.chat
+"""
+from __future__ import annotations
+
+from sopel.config import types
+
+VERBS = (
+    'annihilates',
+    'destroys',
+    'kicks',
+    'owns',
+    'punches',
+    'pwns',
+    'roundhouse kicks',
+    'slaps',
+)
+
+
+class SlapSection(types.StaticSection):
+    verbs = types.ListAttribute('verbs', default=VERBS)
+
+
+def do_configure(section: types.StaticSection):
+    section.configure_setting(
+        'verbs',
+        "\nEnter verbs to choose from when slapping someone, one per line.\n\n"
+        "Alternatively, press Enter twice without typing anything to write\n"
+        "the current list (shown below) to your bot's .cfg file, where it\n"
+        "can be edited using your favorite text editor.\n\n"
+        "Current verb list:",
+    )

--- a/sopel_slap/plugin.py
+++ b/sopel_slap/plugin.py
@@ -12,7 +12,17 @@ from __future__ import annotations
 
 from sopel import plugin
 
+from .config import SlapSection, do_configure
 from .util import slap
+
+
+def setup(bot):
+    bot.settings.define_section('slap', SlapSection)
+
+
+def configure(settings):
+    settings.define_section('slap', SlapSection)
+    do_configure(settings.slap)
 
 
 @plugin.commands('slap', 'slaps')

--- a/sopel_slap/util.py
+++ b/sopel_slap/util.py
@@ -17,17 +17,6 @@ if TYPE_CHECKING:
     from sopel.bot import SopelWrapper
     from sopel.trigger import Trigger
 
-VERBS = (
-    'annihilates',
-    'destroys',
-    'kicks',
-    'owns',
-    'punches',
-    'pwns',
-    'roundhouse kicks',
-    'slaps',
-)
-
 
 def slap(bot: SopelWrapper, trigger: Trigger, target: str):
     """Do the slapping."""
@@ -59,6 +48,6 @@ def slap(bot: SopelWrapper, trigger: Trigger, target: str):
     if target in bot.config.core.admins and not trigger.admin:
         target = trigger.nick
 
-    verb = random.choice(VERBS)
+    verb = random.choice(bot.settings.slap.verbs)
 
     bot.action(f"{verb} {target}")


### PR DESCRIPTION
The same default set, now exposed as a configuration setting that bot owners can override if they wish.