### PR TITLE
Use `action_command` decorator instead of `rule` + general refactor

### DIFF
--- a/sopel_slap/plugin.py
+++ b/sopel_slap/plugin.py
@@ -31,16 +31,16 @@ def slap_command(bot, trigger):
     target = trigger.group(3)
 
     if target is None:
+        # `.slap` is a shortcut for slapping oneself
         target = trigger.nick
 
     return slap(bot, trigger, target)
 
 
-@plugin.ctcp('ACTION')
-@plugin.rule(r'^slaps (\S+)$')
+@plugin.action_command('slaps')
 def slap_action(bot, trigger):
     """Slap someone using the power of CTCP ACTION."""
-    target = trigger.group(1)
+    target = trigger.group(3)
 
     if target is None:
         # no self-slaps via /me; just fail silently

--- a/sopel_slap/plugin.py
+++ b/sopel_slap/plugin.py
@@ -26,24 +26,17 @@ def configure(settings):
 
 
 @plugin.commands('slap', 'slaps')
-def slap_command(bot, trigger):
-    """Slap a <target> (e.g. nickname)"""
-    target = trigger.group(3)
-
-    if target is None:
-        # `.slap` is a shortcut for slapping oneself
-        target = trigger.nick
-
-    return slap(bot, trigger, target)
-
-
 @plugin.action_command('slaps')
-def slap_action(bot, trigger):
-    """Slap someone using the power of CTCP ACTION."""
+@plugin.example('.slap Tr0ll_Extr4ordinair3')
+def slap_command(bot, trigger):
+    """Slap someone else in the channel."""
     target = trigger.group(3)
 
     if target is None:
-        # no self-slaps via /me; just fail silently
-        return plugin.NOLIMIT
+        # `.slap` is a shortcut for slapping oneself, but not in CTCP ACTIONs
+        if trigger.ctcp:
+            return plugin.NOLIMIT
+
+        target = trigger.nick
 
     return slap(bot, trigger, target)


### PR DESCRIPTION
It was certain that something like this would happen one day, and now it has: I forgot about a Sopel API feature and implemented something the "hard way" instead.

Using `action_command` lets Sopel manage coming up with the argument capture groups, and extra arguments beyond the nick are simply ignored (meaning one can do `/me slaps someone for a given reason` and still have the bot perform a slap).

Refactoring to a single callable mostly just reduces line count of the "bot interface" bits, since all the business logic of actually performing a slap got moved to a utility submodule.