### PR TITLE
Protect owners too, not only normal admins

### DIFF
--- a/sopel_slap/util.py
+++ b/sopel_slap/util.py
@@ -45,7 +45,10 @@ def slap(bot: SopelWrapper, trigger: Trigger, target: str):
         else:
             target = 'itself'
 
-    if target in bot.config.core.admins and not trigger.admin:
+    if not trigger.admin and (
+        target == bot.config.core.owner or
+        target in bot.config.core.admins
+    ):
         target = trigger.nick
 
     verb = random.choice(bot.settings.slap.verbs)


### PR DESCRIPTION
The list of admins in Sopel's settings object doesn't include the owner.