### PR TITLE
Add configuration for the bot's reflexive pronoun

### DIFF
--- a/sopel_slap/config.py
+++ b/sopel_slap/config.py
@@ -24,6 +24,10 @@ VERBS = (
 
 class SlapSection(types.StaticSection):
     verbs = types.ListAttribute('verbs', default=VERBS)
+    """Verbs to choose from when slapping someone."""
+
+    reflexive = types.ValidatedAttribute('reflexive', default='itself')
+    """The reflexive pronoun the bot uses when someone slaps it."""
 
 
 def do_configure(section: types.StaticSection):
@@ -34,4 +38,8 @@ def do_configure(section: types.StaticSection):
         "the current list (shown below) to your bot's .cfg file, where it\n"
         "can be edited using your favorite text editor.\n\n"
         "Current verb list:",
+    )
+    section.configure_setting(
+        'reflexive',
+        "What pronoun should the bot use for itself when someone slaps it?",
     )

--- a/sopel_slap/util.py
+++ b/sopel_slap/util.py
@@ -43,7 +43,7 @@ def slap(bot: SopelWrapper, trigger: Trigger, target: str):
         if not trigger.admin:
             target = trigger.nick
         else:
-            target = 'itself'
+            target = bot.settings.slap.reflexive
 
     if target in bot.config.core.admins and not trigger.admin:
         target = trigger.nick


### PR DESCRIPTION
Tin. The default is still "itself", but now the bot owner can change it.