### PR TITLE
util: don't respond if user not found in CTCP ACTION slap

### DIFF
--- a/sopel_slap/util.py
+++ b/sopel_slap/util.py
@@ -36,7 +36,12 @@ def slap(bot: SopelWrapper, trigger: Trigger, target: str):
         return
 
     if target not in bot.channels[trigger.sender].users:
-        bot.reply("You can't slap someone who isn't here!")
+        if not trigger.ctcp:
+            # only reply if a command was used; ignore CTCP ACTIONs
+            # we don't want the bot to be annoying to people who do "/me slaps"
+            # without realizing (or remembering) that the bot responds to it
+            bot.reply("You can't slap someone who isn't here!")
+
         return
 
     if target == bot.nick:


### PR DESCRIPTION
Don't want the bot to be too annoying.

In a busy channel, it can be pretty noisy when people don't know this CTCP ACTION trigger exists.